### PR TITLE
Bug: nior bug reproduction branch

### DIFF
--- a/src/utils.nr
+++ b/src/utils.nr
@@ -1,6 +1,25 @@
 type Stream = [u8; 16];
 type Block = [[u8; 4]; 4];
 
+pub(crate) fn byte_stream_blocks<N>(input: [u8; N]) -> [Block; N / 16] {
+    let nBlocks = input.len() / 16;
+    let mut blocks = [Block::default(); nBlocks];
+    for i in 0..nBlocks {
+        for j in 0..16 {
+            blocks[i][j] = input[i * 16 + j];
+        }
+    }
+    blocks
+}
+
+#[test]
+fn test_to_blocks() {
+    let input = [0u8; 16];
+    let blocks = byte_stream_to_blocks(input);
+    assert(blocks.len() == 1);
+    assert(blocks[0] == input);
+}
+
 pub(crate) fn stream_xor(stream1: Stream, stream2: Stream) -> Stream {
     let mut result: Stream = [0; 16];
     for i in 0..16 {


### PR DESCRIPTION
Running `nargo test` on this branch causes the error
```
The application panicked (crashed).
Message:  type aliases cannot be used in type namespace
Location: compiler/noirc_frontend/src/hir/resolution/import.rs:290

This is a bug. We may have already fixed this in newer versions of Nargo so try searching for similar issues at https://github.com/noir-lang/noir/issues/.
If there isn't an open issue for this bug, consider opening one at https://github.com/noir-lang/noir/issues/new?labels=bug&template=bug_report.yml
```